### PR TITLE
Fix usage of NLC Manager

### DIFF
--- a/src/lib/env.js
+++ b/src/lib/env.js
@@ -11,26 +11,26 @@ const settings = {
 	nlc_username: process.env.HUBOT_WATSON_NLC_USERNAME,
 	nlc_password: process.env.HUBOT_WATSON_NLC_PASSWORD,
 	nlc_classifier: process.env.HUBOT_WATSON_NLC_CLASSIFIER || 'default-hubot-classifier',
+	nlc_enabled: process.env.HUBOT_WATSON_NLC_USERNAME && process.env.HUBOT_WATSON_NLC_PASSWORD,
 	highThreshold: process.env.CONFIDENCE_THRESHOLD_HIGH || '0.9',
 	lowThreshold: process.env.CONFIDENCE_THRESHOLD_LOW || '0.3',
 	messagesToSave: process.env.NEGATIVE_MESSAGES_SAVE_COUNT || '3',
-	paramParsingDisabled: process.env.PARAM_PARSING_DISABLED || false,
-	version: 'v1'
+	paramParsingDisabled: process.env.PARAM_PARSING_DISABLED || false
 };
 
 if (!settings.nlc_url) {
-	console.error('HUBOT_WATSON_NLC_URL not set');
+	console.warn('HUBOT_WATSON_NLC_URL not set. Using default URL for the service.');
 }
 
 if (!settings.nlc_username) {
-	console.error('HUBOT_WATSON_NLC_USERNAME not set');
+	console.warn('HUBOT_WATSON_NLC_USERNAME not set');
 }
 if (!settings.nlc_password) {
-	console.error('HUBOT_WATSON_NLC_PASSWORD not set');
+	console.warn('HUBOT_WATSON_NLC_PASSWORD not set');
 }
 
-if (!settings.nlc_classifier) {
-	console.error('HUBOT_WATSON_NLC_CLASSIFIER not set');
+if (!settings.nlc_username || !settings.nlc_password){
+	console.warn('Natural Language processing has been disabled because Watson Natural Language Clasifier service is not configured.');
 }
 
 settings.lowThreshold = parseFloat(settings.lowThreshold);

--- a/src/lib/watsonServices.js
+++ b/src/lib/watsonServices.js
@@ -1,0 +1,26 @@
+/*
+  * Licensed Materials - Property of IBM
+  * (C) Copyright IBM Corp. 2016. All Rights Reserved.
+  * US Government Users Restricted Rights - Use, duplication or
+  * disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+  */
+'use strict';
+
+const path = require('path');
+const TAG = path.basename(__filename);
+const env = require(path.resolve(__dirname, '..', 'lib', 'env'));
+const NLCManager = require('hubot-ibmcloud-cognitive-lib').nlcManager;
+
+var nlcManager;
+if (env.nlc_enabled) {
+	var watson_nlc_opts = {
+		url: env.nlc_url,
+		username: env.nlc_username,
+		password: env.nlc_password,
+		classifierName: env.nlc_classifier,
+		version: 'v1'
+	};
+	nlcManager = new NLCManager(watson_nlc_opts);
+}
+
+module.exports.nlc = nlcManager;

--- a/src/lib/watsonServices.js
+++ b/src/lib/watsonServices.js
@@ -7,7 +7,6 @@
 'use strict';
 
 const path = require('path');
-const TAG = path.basename(__filename);
 const env = require(path.resolve(__dirname, '..', 'lib', 'env'));
 const NLCManager = require('hubot-ibmcloud-cognitive-lib').nlcManager;
 

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -14,8 +14,10 @@
   "nlc.feedback.negative": "Sorry I misunderstood you. I'll report this mistake. Can you repeat your request in a different way?",
   "nlc.train.prompt": "Do you want to start a new training session?",
   "nlc.train.decline": "Ok, I won't train for now.",
-  "nlc.train.new.session": "Ok, I'm going to start a new training session. Training a classifier takes about 10 minutes.",
+  "nlc.train.new.session": "Ok, I'm going to start a new training session. Training a classifier takes about 15 minutes.",
+  "nlc.train.not.configured" : "I'm unable to start a new training session because the Natural Language service hasn't been configured.",
   "nlc.help": "I'm trained to help with Bluemix DevOps.  To see what I can do type `help`.",
+  "nlc.no.match": "Your request didn't match any supported actions.  To see what I can do type `help`.",
 
   "cognitive.prompt.param": "OK. What is the value for the *%s* parameter?",
   "cognitive.prompt.param.again": "Couldn't extract the *%s* parameter, please try to say only the parameter value."

--- a/src/scripts/nlc.train.js
+++ b/src/scripts/nlc.train.js
@@ -16,11 +16,12 @@
 // Start of the HUBOT interactions.
 // ----------------------------------------------------
 
+const path = require('path');
+const TAG = path.basename(__filename);
 const utils = require('hubot-ibmcloud-utils').utils;
 const Conversation = require('hubot-conversation');
-const NLCManager = require('hubot-ibmcloud-cognitive-lib').nlcManager;
 const env = require('../lib/env');
-var path = require('path');
+const watsonServices = require(path.resolve(__dirname, '..', 'lib', 'watsonServices'));
 
 // --------------------------------------------------------------
 // i18n (internationalization)
@@ -42,15 +43,6 @@ i18n.setLocale('en');
 const TRAIN = /nlc:train/i;
 
 module.exports = function(robot) {
-
-	var nlcManager = new NLCManager({
-		url: env.nlc_url,
-		username: env.nlc_username,
-		password: env.nlc_password,
-		classifierName: env.nlc_classifier,
-		version: 'v1'
-	}, robot);
-
 	var switchBoard = new Conversation(robot);
 
 	robot.on(path.basename(__filename), (res) => {
@@ -64,16 +56,21 @@ module.exports = function(robot) {
 	function train(res){
 		utils.getConfirmedResponse(res, switchBoard, i18n.__('nlc.train.prompt'), i18n.__('nlc.train.decline')).then((result) => {
 
-			res.reply(i18n.__('nlc.train.new.session'));
-
-			nlcManager.train().then(function(trainingResult){
-				res.reply(trainingResult.status_description);
-				return nlcManager.monitorTraining(trainingResult.classifier_id);
-			}).then(function(result){
-				res.reply(result.status_description);
-			}).catch(function(err){
-				robot.logger.error('Error while training a new classifier', err);
-			});
+			if (env.nlc_enabled) {
+				res.reply(i18n.__('nlc.train.new.session'));
+				watsonServices.nlc.train().then(function(trainingResult){
+					res.reply(trainingResult.status_description);
+					return watsonServices.nlc.monitorTraining(trainingResult.classifier_id);
+				}).then(function(result){
+					res.reply(result.status_description);
+				}).catch(function(err){
+					robot.logger.error(`${TAG} Error while training a new classifier. Error=${JSON.stringify(err, null, 2)}`);
+				});
+			}
+			else {
+				robot.logger.error(`${TAG}: Unable to start a training session because the Natural Language service has not been enabled.`);
+				res.reply(i18n.__('nlc.train.not.configured'));
+			}
 		});
 	}
 };

--- a/test/.env
+++ b/test/.env
@@ -1,4 +1,5 @@
 export npm_config_test=true
+export HUBOT_LOG_LEVEL=ERROR
 export HUBOT_WATSON_NLC_URL=https://watson-nlc-api
 export HUBOT_WATSON_NLC_USERNAME=abc
 export HUBOT_WATSON_NLC_PASSWORD=123

--- a/test/nlc.test.js
+++ b/test/nlc.test.js
@@ -263,3 +263,31 @@ describe('Test NLC error path', function(){
 		});
 	});
 });
+
+describe('Test ENV setup', function(){
+
+	let room;
+	beforeEach(function() {
+		env.nlc_enabled = false;
+		room = helper.createRoom();
+	});
+
+	afterEach(function() {
+		env.nlc_enabled = true;
+		room.destroy();
+	});
+
+	it('should not process statement as NLC when environment is not set.', function(done){
+		room.user.say('mimiron', 'hubot Can you process Natural Language?').then(() => {
+			return sprinkles.eventually({ timeout: timeout }, function(){
+				if (room.messages.length < 1){
+					throw new Error('too soon');
+				}
+			}).then(() => false).catch(() => true).then((success) => {
+				expect(room.messages.length).to.eql(2);
+				expect(room.messages[1][1]).to.eql('Your request didn\'t match any supported actions.  To see what I can do type `help`.');
+				done();
+			});
+		});
+	});
+});

--- a/test/nlc.test.js
+++ b/test/nlc.test.js
@@ -230,63 +230,70 @@ describe('Test the NLC interaction', function(){
 			});
 
 		});
-
-	});
-});
-
-describe('Test NLC error path', function(){
-	var room;
-	before(function(){
-		mockNLP.setupMockErrors();
 	});
 
-	beforeEach(function() {
-		room = helper.createRoom();
+
+	describe('User starts a new training session', function(){
+		it('should start training a new classifier', function(done){
+			room.user.say('mimiron', 'hubot nlc:train').then(() => {
+				room.user.say('mimiron', 'yes');
+				return sprinkles.eventually({ timeout: timeout }, function(){
+					if (room.messages.length < 4){
+						throw new Error('too soon');
+					}
+				}).then(() => false).catch(() => true).then((success) => {
+
+					expect(room.messages.length).to.eql(4);
+					expect(room.messages[3][1]).to.eql('@mimiron Ok, I\'m going to start a new training session. Training a classifier takes about 15 minutes.');
+					done();
+				});
+			});
+
+		});
 	});
 
-	afterEach(function() {
-		room.destroy();
-	});
 
-	it('should fail gracefully when Watson NLC service has a 500 error.', function(done){
-		room.user.say('mimiron', 'hubot high confidence result').then(() => {
-			return sprinkles.eventually({ timeout: timeout }, function(){
-				if (room.messages.length < 2){
-					throw new Error('too soon');
-				}
-			}).then(() => false).catch(() => true).then((success) => {
-				expect(room.messages.length).to.eql(3);
-				expect(room.messages[1][1]).to.eql('I\'m having trouble processing natural language requests.  If the problem persist contact your bot administrator.');
-				expect(room.messages[2][1]).to.eql('In the meantime type `help` for a list of available commands.');
-				done();
+	describe('Test ENV setup', function(){
+		before(function() {
+			env.nlc_enabled = false;
+		});
+		after(function() {
+			env.nlc_enabled = true;
+		});
+
+		it('should not process statement as NLC when environment is not set.', function(done){
+			room.user.say('mimiron', 'hubot Can you process Natural Language?').then(() => {
+				return sprinkles.eventually({ timeout: timeout }, function(){
+					if (room.messages.length < 1){
+						throw new Error('too soon');
+					}
+				}).then(() => false).catch(() => true).then((success) => {
+					expect(room.messages.length).to.eql(2);
+					expect(room.messages[1][1]).to.eql('Your request didn\'t match any supported actions.  To see what I can do type `help`.');
+					done();
+				});
 			});
 		});
 	});
-});
 
-describe('Test ENV setup', function(){
 
-	let room;
-	beforeEach(function() {
-		env.nlc_enabled = false;
-		room = helper.createRoom();
-	});
+	describe('Test NLC error path', function(){
+		before(function(){
+			mockNLP.setupMockErrors();
+		});
 
-	afterEach(function() {
-		env.nlc_enabled = true;
-		room.destroy();
-	});
-
-	it('should not process statement as NLC when environment is not set.', function(done){
-		room.user.say('mimiron', 'hubot Can you process Natural Language?').then(() => {
-			return sprinkles.eventually({ timeout: timeout }, function(){
-				if (room.messages.length < 1){
-					throw new Error('too soon');
-				}
-			}).then(() => false).catch(() => true).then((success) => {
-				expect(room.messages.length).to.eql(2);
-				expect(room.messages[1][1]).to.eql('Your request didn\'t match any supported actions.  To see what I can do type `help`.');
-				done();
+		it('should fail gracefully when Watson NLC service has a 500 error.', function(done){
+			room.user.say('mimiron', 'hubot high confidence result').then(() => {
+				return sprinkles.eventually({ timeout: timeout }, function(){
+					if (room.messages.length < 2){
+						throw new Error('too soon');
+					}
+				}).then(() => false).catch(() => true).then((success) => {
+					expect(room.messages.length).to.eql(3);
+					expect(room.messages[1][1]).to.eql('I\'m having trouble processing natural language requests.  If the problem persist contact your bot administrator.');
+					expect(room.messages[2][1]).to.eql('In the meantime type `help` for a list of available commands.');
+					done();
+				});
 			});
 		});
 	});


### PR DESCRIPTION
Resolves #5  
- Don’t fail when Watson NLC service env variables aren’t set. Issue #5 
- Instanciate only 1 NLCManager object.
- Provide simple `catchAll` when NLC is disabled.
