### PR TITLE
nlc auto approve command, closes #48

### DIFF
--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -18,11 +18,14 @@
   "nlc.no.match": "Your request didn't match any supported actions.  To see what I can do type `help`.",
 
   "nlc.status.train.duration": "Classifier has been training for %s minute(s).",
-  "nlc.status.new.statements": "I have *%s* new approved training statements. To start a new training session with these statements just ask me or type `nlc train`",
+  "nlc.status.new.statements": "I have *%s* new approved training statements. To start a new training session with these statements just ask me or type *nlc train*",
   "nlc.status.no.statements": "I don't have any new approved training statements.",
   "nlc.status.other.training": "You have a new classifier that has been training for %s minute(s).",
   "nlc.status.prompt": "You do not have any classifiers under *%s*. Would you like to start training one?",
   "nlc.list.no.classifiers": "No classifiers found.",
+  "nlc.auto.approve.set": "Auto approve is set to *%s*.",
+	"nlc.auto.approve.prompt": "Would you like to turn auto approve *%s*?",
+	"nlc.auto.approve.info": "You can toggle it on or off using *nlc auto approve [on|off|true|false]*",
 
   "nlc.help": "I'm trained to help with Bluemix DevOps.  To see what I can do type `help`.",
   "nlc.help.list": "List all the classifiers in the NLC instance.",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -24,7 +24,6 @@
   "nlc.status.prompt": "You do not have any classifiers under *%s*. Would you like to start training one?",
   "nlc.list.no.classifiers": "No classifiers found.",
   "nlc.auto.approve.set": "Auto approve is set to *%s*.",
-  "nlc.auto.approve.prompt": "Would you like to turn auto approve *%s*?",
   "nlc.auto.approve.info": "You can toggle it on or off using *nlc auto approve [on|off|true|false]*",
 
   "nlc.help": "I'm trained to help with Bluemix DevOps.  To see what I can do type `help`.",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -24,8 +24,8 @@
   "nlc.status.prompt": "You do not have any classifiers under *%s*. Would you like to start training one?",
   "nlc.list.no.classifiers": "No classifiers found.",
   "nlc.auto.approve.set": "Auto approve is set to *%s*.",
-	"nlc.auto.approve.prompt": "Would you like to turn auto approve *%s*?",
-	"nlc.auto.approve.info": "You can toggle it on or off using *nlc auto approve [on|off|true|false]*",
+  "nlc.auto.approve.prompt": "Would you like to turn auto approve *%s*?",
+  "nlc.auto.approve.info": "You can toggle it on or off using *nlc auto approve [on|off|true|false]*",
 
   "nlc.help": "I'm trained to help with Bluemix DevOps.  To see what I can do type `help`.",
   "nlc.help.list": "List all the classifiers in the NLC instance.",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -31,6 +31,7 @@
   "nlc.help.list": "List all the classifiers in the NLC instance.",
   "nlc.help.status": "Show current status of the Hubot NLC classifier.",
   "nlc.help.train": "Retrain the Hubot NLC classifier.",
+  "nlc.help.auto.approve": "Toggle auto approve setting for training NLC statements.",
 
   "cognitive.prompt.param": "OK. What is the value for the *%s* parameter?",
   "cognitive.prompt.param.again": "Couldn't extract the *%s* parameter, please try to say only the parameter value."

--- a/src/nlc/NLC.json
+++ b/src/nlc/NLC.json
@@ -64,6 +64,30 @@
 			"Show me my classifiers",
 			"List all nlc"
 	  		]
+		},
+		{
+		"class": "nlc.auto.approve",
+		"description": "Toggle auto approve setting for classifier training statements",
+			"emittarget": "nlc.auto.approve.js",
+			"texts": [
+			"Toggle auto approve",
+			"Automatically approve my statements",
+			"Turn auto approve on",
+			"Turn auto approve off"
+				],
+	       "parameters" : [
+			   {
+			       "name": "autoapprove",
+			       "type": "keyword",
+			       "prompt": "OK. Do you want auto approve on or off?"
+			   }
+	       ]
 		}
-	]
+	],
+   "parameter.values" : [
+       {
+           "name": "autoapprove",
+           "values": ["on", "off", "true", "false"]
+       }
+   ]
 }

--- a/src/nlc/NLC.json
+++ b/src/nlc/NLC.json
@@ -5,7 +5,7 @@
 	    {
 	      "class": "nlc.help",
 	      "description": "Get help for using the bot",
-	      "emittarget": "nlc.help.js",
+	      "emittarget": "nlc.help",
 	      "texts": [
 			"How can you help me?",
 			"What can you do for me?",
@@ -16,7 +16,7 @@
 			{
 	      "class": "nlc.management.help",
 	      "description": "Get help for managing classifiers",
-	      "emittarget": "nlc.management.help.js",
+	      "emittarget": "nlc.management.help",
 	      "texts": [
 			"Help me with nlc",
 			"Need assitance with natural language",
@@ -27,7 +27,7 @@
 	    {
 	      "class": "nlc.feedback.negative",
 	      "description": "Report natural language misinterpretation",
-	      "emittarget": "nlc.feedback.negative.js",
+	      "emittarget": "nlc.feedback.negative",
 	      "texts": [
 			"That’s not what I asked for!",
 			"That’s incorrect.",
@@ -37,7 +37,7 @@
 	    {
 	      "class": "nlc.train",
 	      "description": "Train the natural language classifier",
-	      "emittarget": "nlc.train.js",
+	      "emittarget": "nlc.train",
 	      "texts": [
 			"Start a training session.",
 			"Go train",
@@ -48,7 +48,7 @@
 		{
 		"class": "nlc.status",
 		"description": "Show the status for the natural language classifier",
-	  	"emittarget": "nlc.status.js",
+	  	"emittarget": "nlc.status",
 	  	"texts": [
 			"Provide the status for my classifier",
 			"Obtain the status of classifier",
@@ -58,7 +58,7 @@
 		{
 		"class": "nlc.list",
 		"description": "List all classifiers with their status",
-	  	"emittarget": "nlc.list.js",
+	  	"emittarget": "nlc.list",
 	  	"texts": [
 			"List my classifiers",
 			"Show me my classifiers",
@@ -68,7 +68,7 @@
 		{
 		"class": "nlc.auto.approve",
 		"description": "Toggle auto approve setting for classifier training statements",
-			"emittarget": "nlc.auto.approve.js",
+			"emittarget": "nlc.auto.approve",
 			"texts": [
 			"Toggle auto approve",
 			"Automatically approve my statements",

--- a/src/scripts/nlc.auto.approve.js
+++ b/src/scripts/nlc.auto.approve.js
@@ -1,0 +1,71 @@
+// Description:
+//	Initiate training of a new Watson Natural Language Classifier
+//
+// Configuration:
+//	 HUBOT_WATSON_NLC_URL api for the Watson Natural Language Classifier service
+//	 HUBOT_WATSON_NLC_USERNAME user ID for the Watson NLC service
+//	 HUBOT_WATSON_NLC_PASSWORD password for the Watson NLC service
+//	 HUBOT_WATSON_NLC_CLASSIFIER name of the classifier for Watson NLC service
+//
+// Author:
+//   reicruz
+//
+'use strict';
+
+// ----------------------------------------------------
+// Start of the HUBOT interactions.
+// ----------------------------------------------------
+
+const path = require('path');
+const TAG = path.basename(__filename);
+const nlcconfig = require('hubot-ibmcloud-cognitive-lib').nlcconfig;
+
+// --------------------------------------------------------------
+// i18n (internationalization)
+// It will read from a peer messages.json file.  Later, these
+// messages can be referenced throughout the module.
+// --------------------------------------------------------------
+const i18n = new (require('i18n-2'))({
+	locales: ['en'],
+	extension: '.json',
+	// Add more languages to the list of locales when the files are created.
+	directory: __dirname + '/../messages',
+	defaultLocale: 'en',
+	// Prevent messages file from being overwritten in error conditions (like poor JSON).
+	updateFiles: false
+});
+// At some point we need to toggle this setting based on some user input.
+i18n.setLocale('en');
+
+const AUTO_APPROVE = /nlc\s(auto approve)\s?(on|off|true|false)?/i;
+
+module.exports = function(robot) {
+	robot.on(path.basename(__filename), (res, parameters) => {
+		robot.logger.debug(`${TAG}: Natural Language match.`);
+		if (parameters && parameters.autoapprove) {
+			updateAutoApprove(res, parameters.autoapprove);
+		}
+		else {
+			updateAutoApprove(res);
+		}
+	});
+
+	robot.respond(AUTO_APPROVE, {id: 'nlc.auto.approve'}, (res) => {
+		robot.logger.debug(`${TAG}: RegEx match.`);
+		updateAutoApprove(res, res.match[2]);
+	});
+
+	function updateAutoApprove(res, value){
+		var approve;
+		if (value) {
+			approve = ['on', 'true'].indexOf(value) > -1;
+			nlcconfig.setAutoApprove(approve);
+			robot.emit('ibmcloud.formatter', { response: res, message: i18n.__('nlc.auto.approve.set', approve)});
+		}
+		else {
+			approve = nlcconfig.getAutoApprove();
+			var message = `${i18n.__('nlc.auto.approve.set', approve)} ${i18n.__('nlc.auto.approve.info')}`;
+			robot.emit('ibmcloud.formatter', { response: res, message: message});
+		}
+	}
+};

--- a/src/scripts/nlc.auto.approve.js
+++ b/src/scripts/nlc.auto.approve.js
@@ -18,6 +18,7 @@
 
 const path = require('path');
 const TAG = path.basename(__filename);
+const env = require('../lib/env');
 const nlcconfig = require('hubot-ibmcloud-cognitive-lib').nlcconfig;
 
 // --------------------------------------------------------------
@@ -56,16 +57,22 @@ module.exports = function(robot) {
 	});
 
 	function updateAutoApprove(res, value){
-		var approve;
-		if (value) {
-			approve = ['on', 'true'].indexOf(value) > -1;
-			nlcconfig.setAutoApprove(approve);
-			robot.emit('ibmcloud.formatter', { response: res, message: i18n.__('nlc.auto.approve.set', approve)});
+		if (env.nlc_enabled) {
+			var approve;
+			if (value) {
+				approve = ['on', 'true'].indexOf(value) > -1;
+				nlcconfig.setAutoApprove(approve);
+				robot.emit('ibmcloud.formatter', { response: res, message: i18n.__('nlc.auto.approve.set', approve)});
+			}
+			else {
+				approve = nlcconfig.getAutoApprove();
+				var message = `${i18n.__('nlc.auto.approve.set', approve)} ${i18n.__('nlc.auto.approve.info')}`;
+				robot.emit('ibmcloud.formatter', { response: res, message: message});
+			}
 		}
 		else {
-			approve = nlcconfig.getAutoApprove();
-			var message = `${i18n.__('nlc.auto.approve.set', approve)} ${i18n.__('nlc.auto.approve.info')}`;
-			robot.emit('ibmcloud.formatter', { response: res, message: message});
+			robot.emit('ibmcloud.formatter', { response: res, message: i18n.__('nlc.train.not.configured')});
+			robot.logger.error(`${TAG} NLC is not configured.`);
 		}
 	}
 };

--- a/src/scripts/nlc.auto.approve.js
+++ b/src/scripts/nlc.auto.approve.js
@@ -41,7 +41,7 @@ i18n.setLocale('en');
 const AUTO_APPROVE = /nlc\s(auto approve)\s?(on|off|true|false)?/i;
 
 module.exports = function(robot) {
-	robot.on(path.basename(__filename), (res, parameters) => {
+	robot.on('nlc.auto.approve', (res, parameters) => {
 		robot.logger.debug(`${TAG}: Natural Language match.`);
 		if (parameters && parameters.autoapprove) {
 			updateAutoApprove(res, parameters.autoapprove);

--- a/src/scripts/nlc.catchall.js
+++ b/src/scripts/nlc.catchall.js
@@ -72,14 +72,14 @@ function processNLC(robot, text) {
 				// If high confidence emit to nlc.confidence.high.js to handle
 				if (response.classes[0].confidence > env.highThreshold){
 					resolve({
-						target: 'nlc.confidence.high.js',
+						target: 'nlc.confidence.high',
 						parameters: response
 					});
 				}
 				// If medium confidence emit to nlc.confidence.med.js to handle
 				else if (response.classes[0].confidence > env.lowThreshold && response.classes[0].confidence <= env.highThreshold){
 					resolve({
-						target: 'nlc.confidence.med.js',
+						target: 'nlc.confidence.med',
 						parameters: response
 					});
 				}
@@ -87,7 +87,7 @@ function processNLC(robot, text) {
 				// If low confidence emit to nlc.confidence.low.js to handle
 				else {
 					resolve({
-						target: 'nlc.confidence.low.js',
+						target: 'nlc.confidence.low',
 						parameters: response
 					});
 

--- a/src/scripts/nlc.confidence.high.js
+++ b/src/scripts/nlc.confidence.high.js
@@ -46,7 +46,7 @@ module.exports = function(robot) {
 
 	let paramManager = new ParamManager();
 
-	robot.on(path.basename(__filename), (res, classification) => {
+	robot.on('nlc.confidence.high', (res, classification) => {
 		// TODO: Remove displaying of top classes and confidence back to user.
 		robot.logger.info(`${TAG} High confidence detected.`);
 		robot.emit('ibmcloud.formatter', { response: res, message: i18n.__('nlc.confidence.high.process', classification.top_class)});

--- a/src/scripts/nlc.confidence.low.js
+++ b/src/scripts/nlc.confidence.low.js
@@ -42,7 +42,7 @@ i18n.setLocale('en');
 
 module.exports = function(robot) {
 
-	robot.on(path.basename(__filename), (res, classification) => {
+	robot.on('nlc.confidence.low', (res, classification) => {
 		robot.logger.info(`${TAG} Low confidence detected`);
 		robot.emit('ibmcloud.formatter', { response: res, message: i18n.__('nlc.confidence.low.prompt')});
 

--- a/src/scripts/nlc.confidence.med.js
+++ b/src/scripts/nlc.confidence.med.js
@@ -52,7 +52,7 @@ module.exports = function(robot) {
 	let paramManager = new ParamManager();
 	let switchBoard = new Conversation(robot);
 
-	robot.on(path.basename(__filename), (res, classification) => {
+	robot.on('nlc.confidence.med', (res, classification) => {
 		// promise result is cached
 		nlcDb.open().then((db) => {
 			let descriptionPromises = classification.classes.map((clz) => {

--- a/src/scripts/nlc.feedback.negative.js
+++ b/src/scripts/nlc.feedback.negative.js
@@ -42,7 +42,7 @@ i18n.setLocale('en');
 
 module.exports = function(robot) {
 
-	robot.on(path.basename(__filename), (res, info) => {
+	robot.on('nlc.feedback.negative', (res, info) => {
 		robot.logger.debug(`${TAG} Detected negative feedback for Natural Language match. info=${JSON.stringify(info, null, 2)}`);
 		robot.emit('ibmcloud.formatter', { response: res, message: i18n.__('nlc.feedback.negative')});
 

--- a/src/scripts/nlc.help.js
+++ b/src/scripts/nlc.help.js
@@ -33,11 +33,9 @@ i18n.setLocale('en');
 // ----------------------------------------------------
 // Start of the HUBOT interactions.
 // ----------------------------------------------------
-var path = require('path');
-
 module.exports = function(robot) {
 
-	robot.on(path.basename(__filename), (res) => {
+	robot.on('nlc.help', (res) => {
 		robot.emit('ibmcloud.formatter', {response: res, message: i18n.__('nlc.help')});
 	});
 

--- a/src/scripts/nlc.list.js
+++ b/src/scripts/nlc.list.js
@@ -43,7 +43,7 @@ module.exports = function(robot) {
 	};
 
 	// Natural Language match
-	robot.on(path.basename(__filename), (res, parameters) => {
+	robot.on('nlc.list', (res, parameters) => {
 		robot.logger.debug(`${TAG}: nlc.list - Natural Language match.`);
 		getClassifierList(res);
 	});

--- a/src/scripts/nlc.management.help.js
+++ b/src/scripts/nlc.management.help.js
@@ -51,8 +51,9 @@ module.exports = (robot) => {
 
 	function getHelp(robot, res) {
 		let help = `${robot.name} nlc status - ` + i18n.__('nlc.help.status') + '\n';
-		help += `${robot.name} nlc list|show  - ` + i18n.__('nlc.help.list') + '\n';
-		help += `${robot.name} nlc train|retrain  - ` + i18n.__('nlc.help.train') + '\n';
+		help += `${robot.name} nlc list|show - ` + i18n.__('nlc.help.list') + '\n';
+		help += `${robot.name} nlc train|retrain - ` + i18n.__('nlc.help.train') + '\n';
+		help += `${robot.name} nlc auto approve [on|off|true|false] - ` + i18n.__('nlc.help.auto.approve') + '\n';
 
 		let message = '\n' + help;
 		robot.emit('ibmcloud.formatter', {response: res, message: message});

--- a/src/scripts/nlc.management.help.js
+++ b/src/scripts/nlc.management.help.js
@@ -37,7 +37,7 @@ const NLC_HELP = /nlc (help)$/i;
 
 module.exports = (robot) => {
 	// Natural Language match
-	robot.on(path.basename(__filename), (res, parameters) => {
+	robot.on('nlc.management.help', (res, parameters) => {
 		robot.logger.debug(`${TAG}: Natural Language match. res.message.text=${res.message.text}.`);
 		getHelp(robot, res);
 	});

--- a/src/scripts/nlc.status.js
+++ b/src/scripts/nlc.status.js
@@ -48,7 +48,7 @@ module.exports = function(robot) {
 	};
 
 	// Natural Language match
-	robot.on(path.basename(__filename), (res, parameters) => {
+	robot.on('nlc.status', (res, parameters) => {
 		robot.logger.debug(`${TAG}: nlc.status - Natural Language match.`);
 		getStatus(res);
 	});

--- a/src/scripts/nlc.train.js
+++ b/src/scripts/nlc.train.js
@@ -45,7 +45,7 @@ const TRAIN = /nlc (train|retrain)$/i;
 module.exports = function(robot) {
 	var switchBoard = new Conversation(robot);
 
-	robot.on(path.basename(__filename), (res) => {
+	robot.on('nlc.train', (res) => {
 		robot.logger.debug(`${TAG}: nlc.train - Natural Language match.`);
 		train(res);
 	});

--- a/test/nlc.cognitive.tests.js
+++ b/test/nlc.cognitive.tests.js
@@ -49,7 +49,7 @@ describe('Interacting with NLC commands via Natural Language', function() {
 				}
 			});
 			var res = { message: {text: 'status of my classifier', user: {id: 'mimiron'}}, response: room };
-			room.robot.emit('nlc.status.js', res, {});
+			room.robot.emit('nlc.status', res, {});
 		});
 	});
 
@@ -65,7 +65,7 @@ describe('Interacting with NLC commands via Natural Language', function() {
 				}
 			});
 			var res = { message: {text: 'list my classifiers', user: {id: 'mimiron'}}, response: room };
-			room.robot.emit('nlc.list.js', res, {});
+			room.robot.emit('nlc.list', res, {});
 		});
 	});
 
@@ -83,7 +83,7 @@ describe('Interacting with NLC commands via Natural Language', function() {
 			});
 
 			var res = { message: {text: 'help with nlc', user: {id: 'mimiron'}}, response: room };
-			room.robot.emit('nlc.management.help.js', res, {});
+			room.robot.emit('nlc.management.help', res, {});
 		});
 	});
 
@@ -98,7 +98,7 @@ describe('Interacting with NLC commands via Natural Language', function() {
 			});
 
 			var res = { message: {text: 'I need some help', user: {id: 'mimiron'}}, response: room };
-			room.robot.emit('nlc.help.js', res, {});
+			room.robot.emit('nlc.help', res, {});
 		});
 	});
 
@@ -110,7 +110,7 @@ describe('Interacting with NLC commands via Natural Language', function() {
 				done();
 			});
 			var res = { message: {text: 'turn auto approve off', user: {id: 'mimiron'}}, response: room };
-			room.robot.emit('nlc.auto.approve.js', res, { autoapprove: 'on' });
+			room.robot.emit('nlc.auto.approve', res, { autoapprove: 'on' });
 		});
 
 		it('should respond with auto approve value', function(done){
@@ -120,7 +120,7 @@ describe('Interacting with NLC commands via Natural Language', function() {
 				done();
 			});
 			var res = { message: {text: 'auto approve setting', user: {id: 'mimiron'}}, response: room };
-			room.robot.emit('nlc.auto.approve.js', res, {});
+			room.robot.emit('nlc.auto.approve', res, {});
 		});
 	});
 });

--- a/test/nlc.cognitive.tests.js
+++ b/test/nlc.cognitive.tests.js
@@ -100,4 +100,26 @@ describe('Interacting with NLC commands via Natural Language', function() {
 			room.robot.emit('nlc.help.js', res, {});
 		});
 	});
+
+	context('user toggles auto approve', function(){
+		it('should succesfully turn auto approve off', function(done){
+			room.robot.on('ibmcloud.formatter', function(event) {
+				expect(event.message).to.be.a('string');
+				expect(event.message).to.contain(i18n.__('nlc.auto.approve.set', 'true'));
+				done();
+			});
+			var res = { message: {text: 'turn auto approve off', user: {id: 'mimiron'}}, response: room };
+			room.robot.emit('nlc.auto.approve.js', res, { autoapprove: 'on' });
+		});
+
+		it('should respond with auto approve value', function(done){
+			room.robot.on('ibmcloud.formatter', function(event) {
+				expect(event.message).to.be.a('string');
+				expect(event.message).to.contain(i18n.__('nlc.auto.approve.set', 'true'));
+				done();
+			});
+			var res = { message: {text: 'auto approve setting', user: {id: 'mimiron'}}, response: room };
+			room.robot.emit('nlc.auto.approve.js', res, {});
+		});
+	});
 });

--- a/test/nlc.cognitive.tests.js
+++ b/test/nlc.cognitive.tests.js
@@ -77,6 +77,7 @@ describe('Interacting with NLC commands via Natural Language', function() {
 					expect(event.message).to.contain(i18n.__('nlc.help.status'));
 					expect(event.message).to.contain(i18n.__('nlc.help.list'));
 					expect(event.message).to.contain(i18n.__('nlc.help.train'));
+					expect(event.message).to.contain(i18n.__('nlc.help.auto.approve'));
 					done();
 				}
 			});

--- a/test/nlc.tests.js
+++ b/test/nlc.tests.js
@@ -281,6 +281,7 @@ describe('Test the NLC interaction', function(){
 					expect(event.message).to.contain(i18n.__('nlc.help.status'));
 					expect(event.message).to.contain(i18n.__('nlc.help.list'));
 					expect(event.message).to.contain(i18n.__('nlc.help.train'));
+					expect(event.message).to.contain(i18n.__('nlc.help.auto.approve'));
 					done();
 				}
 			});

--- a/test/nlc.tests.js
+++ b/test/nlc.tests.js
@@ -93,7 +93,7 @@ describe('Test the NLC interaction', function(){
 				// add class mapping for negative feedback testing
 				return db.put({
 					_id: 'nlc.feedback.negative',
-					emittarget: 'nlc.feedback.negative.js'
+					emittarget: 'nlc.feedback.negative'
 				});
 			});
 		});
@@ -111,7 +111,7 @@ describe('Test the NLC interaction', function(){
 		it('should emit a low classification event', function(done) {
 			let cntr = 0;
 			let docId;
-			room.robot.on('nlc.confidence.low.js', (res, classification) => {
+			room.robot.on('nlc.confidence.low', (res, classification) => {
 				if (cntr === 0){
 					// check the database for the document miss
 					waitForDocType(db, 'unclassified').then((id) => {
@@ -142,7 +142,7 @@ describe('Test the NLC interaction', function(){
 		});
 
 		it('should emit a medium classification event', function(done) {
-			room.robot.on('nlc.confidence.med.js', (res, classification) => {
+			room.robot.on('nlc.confidence.med', (res, classification) => {
 				return sprinkles.eventually({ timeout: timeout }, function(){
 					if (room.messages.length < 2){
 						throw new Error('too soon');
@@ -167,7 +167,7 @@ describe('Test the NLC interaction', function(){
 
 		it('should emit a medium classification event and not be classified correctly', function(done) {
 			const msg = 'medium confidence result with no classification';
-			room.robot.on('nlc.confidence.med.js', (res, classification) => {
+			room.robot.on('nlc.confidence.med', (res, classification) => {
 				return sprinkles.eventually({ timeout: timeout }, function(){
 					if (room.messages.length < 2){
 						throw new Error('too soon');
@@ -203,7 +203,7 @@ describe('Test the NLC interaction', function(){
 		});
 
 		it('should emit a high classification event', function(done) {
-			room.robot.on('nlc.confidence.high.js', (res, classification) => {
+			room.robot.on('nlc.confidence.high', (res, classification) => {
 				// check the database for the document hit
 				waitForDocType(db, 'classified').then(() => {
 					done();
@@ -219,12 +219,12 @@ describe('Test the NLC interaction', function(){
 			room.user.say('mimiron', 'hubot negative feedback');
 
 			room.robot.on('ibmcloud-auth-to-nlc', (res, target) => {
-				if (target.emitTarget === 'nlc.feedback.negative.js'){
-					room.robot.emit('nlc.feedback.negative.js', res);
+				if (target.emitTarget === 'nlc.feedback.negative'){
+					room.robot.emit('nlc.feedback.negative', res);
 				}
 			});
 
-			room.robot.on('nlc.feedback.negative.js', (res) => {
+			room.robot.on('nlc.feedback.negative', (res) => {
 				// check the database for the document hit
 				waitForDocType(db, 'negative_fb').then((docId) => {
 					db.get(docId).then((doc) => {

--- a/test/nlc.tests.js
+++ b/test/nlc.tests.js
@@ -346,6 +346,15 @@ describe('Test the NLC interaction', function(){
 			room.user.say('mimiron', '@hubot nlc list').then();
 		});
 
+		it('should not auto approve when environment is not set', function(done){
+			room.robot.on('ibmcloud.formatter', function(event) {
+				expect(event.message).to.be.a('string');
+				expect(event.message).to.contain(i18n.__('nlc.train.not.configured'));
+				done();
+			});
+			room.user.say('mimiron', '@hubot nlc auto approve').then();
+		});
+
 		it('should not train classifier when environment is not set', function(done){
 			room.user.say('mimiron', 'hubot nlc train').then(() => {
 				room.user.say('mimiron', 'yes');
@@ -424,6 +433,26 @@ describe('Test the NLC interaction', function(){
 				done();
 			});
 			room.user.say('mimiron', 'hubot nlc list').then();
+		});
+	});
+
+	describe('Test auto approve command', function(){
+		it('should succesfully turn auto approve off', function(done){
+			room.robot.on('ibmcloud.formatter', function(event) {
+				expect(event.message).to.be.a('string');
+				expect(event.message).to.contain(i18n.__('nlc.auto.approve.set', 'true'));
+				done();
+			});
+			room.user.say('mimiron', 'hubot nlc auto approve on').then();
+		});
+
+		it('should respond with auto approve value', function(done){
+			room.robot.on('ibmcloud.formatter', function(event) {
+				expect(event.message).to.be.a('string');
+				expect(event.message).to.contain(i18n.__('nlc.auto.approve.set', 'true'));
+				done();
+			});
+			room.user.say('mimiron', 'hubot nlc auto approve').then();
 		});
 	});
 });


### PR DESCRIPTION
Toggle auto approve setting for nlc training statements. Note that these changes _do not_ persist if the bot is restarted. There could be additional work for the ENV variable to be updated.

`nlc auto approve` - Responds with current auto approve setting
`nlc auto approve [on|off|true|false]` - Enables/disables auto approve
