### PR TITLE
Provide acces to classifier's training data

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ The intended general flow for the natural language processing is as follows:
 - `nlc list|show` - List all the Watson NLC instances.
 - `nlc train|retrain` - Train a new Watson NLC instance with the current training data.
 - `nlc auto approve [on|off|true|false]` - Toggle auto approve of new NLC statements learned from usage.
+- `nlc data [className]` - Show the data used to train the NLC instance.
 
 **Note:** Usage of `auto approve` could have potential negative effects. Auto-approving the classified statements if they include keywords/entities could cause incorrect classifications for other command usages in the future.
 

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -6,6 +6,9 @@
   "nlc.confidence.med.error": "Sorry I couldn't understand. Try to use different words to describe what you need.",
   "nlc.confidence.high.process": "[High confidence] Will process top class [%s]",
 
+  "nlc.data.summary": "NLC instance **%s** was trained with **%s** classifications and **%s** statements.",
+  "nlc.data.title": "Training Data for classifier ID %s",
+
   "nlc.error.fallback": "In the meantime type *help* for a list of available commands.",
   "nlc.error.unexpected.general": "I'm having trouble processing natural language requests. If the problem persist contact your bot administrator.",
   "nlc.process.error": "Sorry, I was unable to process your response.",
@@ -27,7 +30,8 @@
   "nlc.auto.approve.info": "You can toggle it on or off using *nlc auto approve on|off|true|false*",
 
   "nlc.help": "I'm trained to help with Bluemix DevOps.  To see what I can do type *help*.",
-  "nlc.help.list": "List all the Watson NLC instances.",
+  "nlc.help.data": "Show the data used to train the NLC instance.",
+  "nlc.help.list": "List all the Watson NLC instances. Optionally, filter by class name.",
   "nlc.help.status": "Show the status of the Watson NLC instance currently being used by the bot.",
   "nlc.help.train": "Train a new Watson NLC instance with the current training data.",
   "nlc.help.auto.approve": "Toggle auto approve of new NLC statements learned from usage.",

--- a/src/nlc/NLC.json
+++ b/src/nlc/NLC.json
@@ -2,6 +2,17 @@
 	"name": "hubot-ibmcloud-nlc",
 	"version": "0.0.1",
 	"classes": [
+		{
+	      "class": "nlc.data",
+	      "description": "Show data used to train the natural language classifier",
+	      "emittarget": "nlc.data",
+	      "texts": [
+			"Show NLC data",
+			"Get Natural Language training data",
+			"See my training data",
+			"nlc data"
+		  ]
+		},
 	    {
 	      "class": "nlc.help",
 	      "description": "Get help for using the bot",

--- a/src/scripts/nlc.data.js
+++ b/src/scripts/nlc.data.js
@@ -51,22 +51,14 @@ module.exports = function(robot) {
 	// RegEx match
 	robot.respond(NLC_DATA, {id: 'nlc.data'}, function(res) {
 		robot.logger.debug(`${TAG}: nlc.data - RegEx match. `, res.match);
-
-		if (res.match.length > 4) {
-			getNLCData(res, res.match[2], res.match[4]);
-		}
-		else if (res.match.length > 2) {
-			getNLCData(res, res.match[2]);
-		}
-		else {
-			getNLCData(res);
-		}
+		getNLCData(res, res.match[2], res.match[4]);
 	});
 
 	function getNLCData(res, searchClassNames, classifierId) {
 		if (env.nlc_enabled) {
-
-			// If classifierId is provided, use that, otherwise use the current classifier.
+			// NOTE: The ability to provide a classifierId is hidden because users of the bot
+			// only have access to the current classifier. I'm leaving it here because it
+			// was useful for development, we can document it if proven useful for users.
 			new Promise((resolve, reject) => {
 				if (classifierId){
 					resolve(classifierId);

--- a/src/scripts/nlc.data.js
+++ b/src/scripts/nlc.data.js
@@ -1,0 +1,118 @@
+// Description:
+//	 Analyze the data used to train the Watson Natural Language Classifier
+//
+// Configuration:
+//	 HUBOT_WATSON_NLC_URL api for the Watson Natural Language Classifier service
+//	 HUBOT_WATSON_NLC_USERNAME user ID for the Watson NLC service
+//	 HUBOT_WATSON_NLC_PASSWORD password for the Watson NLC service
+//	 HUBOT_WATSON_NLC_CLASSIFIER (OPTIONAL)name of the classifier for Watson NLC service
+//
+// Author:
+//   jlpadilla
+//
+'use strict';
+
+var path = require('path');
+var TAG = path.basename(__filename);
+
+const env = require('../lib/env');
+// const utils = require('hubot-ibmcloud-utils').utils;
+// const palette = require('hubot-ibmcloud-utils').palette;
+// const Conversation = require('hubot-conversation');
+const watsonServices = require(path.resolve(__dirname, '..', 'lib', 'watsonServices'));
+
+// --------------------------------------------------------------
+// i18n (internationalization)
+// It will read from a peer messages.json file.  Later, these
+// messages can be referenced throughout the module.
+// --------------------------------------------------------------
+const i18n = new (require('i18n-2'))({
+	locales: ['en'],
+	extension: '.json',
+	// Add more languages to the list of locales when the files are created.
+	directory: __dirname + '/../messages',
+	defaultLocale: 'en',
+	// Prevent messages file from being overwritten in error conditions (like poor JSON).
+	updateFiles: false
+});
+// At some point we need to toggle this setting based on some user input.
+i18n.setLocale('en');
+
+const NLC_DATA = /(nlc\sdata)\s?((\w|\.)*)?\s?((\w|-)*)?$/i;
+
+module.exports = function(robot) {
+
+	// Natural Language match
+	robot.on('nlc.data', (res, parameters) => {
+		robot.logger.debug(`${TAG}: nlc.data - Natural Language match.`);
+		getNLCData(res);
+	});
+
+	// RegEx match
+	robot.respond(NLC_DATA, {id: 'nlc.data'}, function(res) {
+		robot.logger.debug(`${TAG}: nlc.data - RegEx match. `, res.match);
+
+		if (res.match.length > 4) {
+			getNLCData(res, res.match[2], res.match[4]);
+		}
+		else if (res.match.length > 2) {
+			getNLCData(res, res.match[2]);
+		}
+		else {
+			getNLCData(res);
+		}
+	});
+
+	function getNLCData(res, searchClassNames, classifierId) {
+		if (env.nlc_enabled) {
+
+			// If classifierId is provided, use that, otherwise use the current classifier.
+			new Promise((resolve, reject) => {
+				if (classifierId){
+					resolve(classifierId);
+				}
+				else {
+					watsonServices.nlc.currentClassifier().then((classifier) => {
+						resolve(classifier.classifier_id);
+					});
+				}
+			})
+			.then((classifierId) => {
+				watsonServices.nlc.getClassifierData(classifierId).then((trained_data) => {
+					robot.logger.debug(`${TAG}: Got classifier data for classifier with classifierId=${classifierId}.`);
+
+					let totalStatements = 0;
+					let totalClasses = 0;
+					let fields = [];
+					for (var key in trained_data) {
+						totalClasses++;
+						if (!searchClassNames || key.toLowerCase().indexOf(searchClassNames.toLowerCase()) >= 0) {
+							totalStatements += trained_data[key].length;
+							let values = '';
+							trained_data[key].forEach(function(stmt){
+								values += stmt + '\n';
+							});
+							fields.push({title: key, value: values, short: true});
+						}
+					}
+
+					let msg = i18n.__('nlc.data.summary', classifierId, totalClasses, totalStatements);
+					robot.emit('ibmcloud.formatter', {response: res, message: msg});
+					robot.emit('ibmcloud.formatter', {response: res, attachments: [
+						{
+							title: i18n.__('nlc.data.title', classifierId),
+							fields: fields,
+							short: true
+						}
+					]});
+				}).catch((err) => {
+					robot.logger.error(`${TAG} Error getting classifier trained data. classifierId=${classifierId}`, err);
+				});
+			});
+		}
+		else {
+			robot.logger.warning(`${TAG} NLC is not configured.`);
+			robot.emit('ibmcloud.formatter', { response: res, message: i18n.__('nlc.train.not.configured')});
+		}
+	}
+};

--- a/src/scripts/nlc.management.help.js
+++ b/src/scripts/nlc.management.help.js
@@ -54,6 +54,7 @@ module.exports = (robot) => {
 		help += `${robot.name} nlc list|show - ` + i18n.__('nlc.help.list') + '\n';
 		help += `${robot.name} nlc train|retrain - ` + i18n.__('nlc.help.train') + '\n';
 		help += `${robot.name} nlc auto approve [on|off|true|false] - ` + i18n.__('nlc.help.auto.approve') + '\n';
+		help += `${robot.name} nlc data [className] - ` + i18n.__('nlc.help.data') + '\n';
 
 		let message = '\n' + help;
 		robot.emit('ibmcloud.formatter', {response: res, message: message});

--- a/src/scripts/nlc.status.js
+++ b/src/scripts/nlc.status.js
@@ -119,8 +119,8 @@ module.exports = function(robot) {
 			});
 		}
 		else {
+			robot.logger.warning(`${TAG} NLC is not configured.`);
 			robot.emit('ibmcloud.formatter', { response: res, message: i18n.__('nlc.train.not.configured')});
-			robot.logger.error(`${TAG} NLC is not configured.`);
 		}
 	}
 };

--- a/test/.env
+++ b/test/.env
@@ -1,4 +1,5 @@
 export npm_config_test=true
+export SUPPRESS_ERRORS=true
 export HUBOT_LOG_LEVEL=ERROR
 export HUBOT_WATSON_NLC_URL=https://watson-nlc-api
 export HUBOT_WATSON_NLC_USERNAME=abc

--- a/test/nlc.cognitive.tests.js
+++ b/test/nlc.cognitive.tests.js
@@ -108,6 +108,7 @@ describe('Interacting with NLC commands via Natural Language', function() {
 					expect(event.message).to.contain(i18n.__('nlc.help.list'));
 					expect(event.message).to.contain(i18n.__('nlc.help.train'));
 					expect(event.message).to.contain(i18n.__('nlc.help.auto.approve'));
+					expect(event.message).to.contain(i18n.__('nlc.help.data'));
 					done();
 				}
 			});

--- a/test/nlc.cognitive.tests.js
+++ b/test/nlc.cognitive.tests.js
@@ -10,6 +10,7 @@ const expect = require('chai').expect;
 const Helper = require('hubot-test-helper');
 const helper = new Helper('../src/scripts');
 const mockUtils = require('./nlc.mock');
+const nlcDb = require('hubot-ibmcloud-cognitive-lib').nlcDb;
 
 const i18n = new (require('i18n-2'))({
 	locales: ['en'],
@@ -25,9 +26,21 @@ i18n.setLocale('en');
 
 describe('Interacting with NLC commands via Natural Language', function() {
 	let room;
+	let db;
 
 	before(function() {
 		mockUtils.setupMockery();
+		return nlcDb.open().then((res) => {
+			db = res;
+			// add classifier data for current classifier, only if it hasn't been added. Data may exist if nlc.tests runs first.
+			return db.get('cd02b5x110-nlc-5103').catch(() => {
+				return db.put({
+					_id: 'cd02b5x110-nlc-5103',
+					type: 'classifier_data',
+					trainedData: 'Sample classification text,classification\nSample classification text 2,classification\nSample classification text 3,classification3'
+				});
+			});
+		});
 	});
 
 	beforeEach(function() {
@@ -66,6 +79,23 @@ describe('Interacting with NLC commands via Natural Language', function() {
 			});
 			var res = { message: {text: 'list my classifiers', user: {id: 'mimiron'}}, response: room };
 			room.robot.emit('nlc.list', res, {});
+		});
+	});
+
+	context('user asks for classifier data', function() {
+		it('should reply with slack attachment with classifier data', function(done){
+			room.robot.on('ibmcloud.formatter', function(event) {
+				if (event.attachments && event.attachments.length >= 1){
+					expect(event.attachments.length).to.eql(1);
+					expect(event.attachments[0].title).to.eql('Training Data for classifier ID cd02b5x110-nlc-5103');
+					expect(event.attachments[0].fields.length).to.eql(2);
+					expect(event.attachments[0].fields[0].title).to.eql('classification');
+					expect(event.attachments[0].fields[0].value).to.eql('Sample classification text\nSample classification text 2\n');
+					done();
+				}
+			});
+			var res = { message: {text: 'data for my classifier', user: {id: 'mimiron'}}, response: room };
+			room.robot.emit('nlc.data', res, {});
 		});
 	});
 

--- a/test/nlc.tests.js
+++ b/test/nlc.tests.js
@@ -96,11 +96,13 @@ describe('Test the NLC interaction', function(){
 					emittarget: 'nlc.feedback.negative'
 				});
 			}).then(() => {
-				// add classifier data for furrent classifier
-				return db.put({
-					_id: 'cd02b5x110-nlc-5103',
-					type: 'classifier_data',
-					trainedData: 'Sample classification text,classification\nSample classification text 2,classification\nSample classification text 3,classification3'
+				// add classifier data for current classifier, only if it hasn't been added. Data may exist if nlc.cognitive.tests runs first.
+				return db.get('cd02b5x110-nlc-5103').catch(() => {
+					return db.put({
+						_id: 'cd02b5x110-nlc-5103',
+						type: 'classifier_data',
+						trainedData: 'Sample classification text,classification\nSample classification text 2,classification\nSample classification text 3,classification3'
+					});
 				});
 			}).then(() => {
 				// add classifier data
@@ -275,7 +277,6 @@ describe('Test the NLC interaction', function(){
 	describe('user asks for classifier data for current classifier', function() {
 		it('should reply with slack attachment with current classifier data', function(done){
 			room.robot.on('ibmcloud.formatter', function(event) {
-				// console.log(event);
 				if (event.message){
 					expect(event.message).to.be.eql('NLC instance **cd02b5x110-nlc-5103** was trained with **2** classifications and **3** statements.');
 				}
@@ -408,6 +409,15 @@ describe('Test the NLC interaction', function(){
 			room.user.say('mimiron', '@hubot nlc train').then(() => {
 				room.user.say('mimiron', 'yes');
 			});
+		});
+
+		it('should not check classifier data when environment is not set', function(done){
+			room.robot.on('ibmcloud.formatter', function(event) {
+				expect(event.message).to.be.a('string');
+				expect(event.message).to.contain(i18n.__('nlc.train.not.configured'));
+				done();
+			});
+			room.user.say('mimiron', '@hubot nlc data');
 		});
 	});
 

--- a/test/nlc.tests.js
+++ b/test/nlc.tests.js
@@ -95,6 +95,20 @@ describe('Test the NLC interaction', function(){
 					_id: 'nlc.feedback.negative',
 					emittarget: 'nlc.feedback.negative'
 				});
+			}).then(() => {
+				// add classifier data for furrent classifier
+				return db.put({
+					_id: 'cd02b5x110-nlc-5103',
+					type: 'classifier_data',
+					trainedData: 'Sample classification text,classification\nSample classification text 2,classification\nSample classification text 3,classification3'
+				});
+			}).then(() => {
+				// add classifier data
+				return db.put({
+					_id: 'cd02b5x110-nlc-0000',
+					type: 'classifier_data',
+					trainedData: 'Sample text,classification\nSample text 2,classification\nSample text 3,classification3'
+				});
 			});
 		});
 	});
@@ -255,6 +269,45 @@ describe('Test the NLC interaction', function(){
 				}
 			});
 			room.user.say('mimiron', '@hubot nlc status');
+		});
+	});
+
+	describe('user asks for classifier data for current classifier', function() {
+		it('should reply with slack attachment with current classifier data', function(done){
+			room.robot.on('ibmcloud.formatter', function(event) {
+				// console.log(event);
+				if (event.message){
+					expect(event.message).to.be.eql('NLC instance **cd02b5x110-nlc-5103** was trained with **2** classifications and **3** statements.');
+				}
+				if (event.attachments && event.attachments.length >= 1){
+					expect(event.attachments.length).to.eql(1);
+					expect(event.attachments[0].title).to.eql('Training Data for classifier ID cd02b5x110-nlc-5103');
+					expect(event.attachments[0].fields).to.have.length(2);
+					expect(event.attachments[0].fields[0].title).to.eql('classification');
+					expect(event.attachments[0].fields[0].value).to.eql('Sample classification text\nSample classification text 2\n');
+					done();
+				}
+			});
+			room.user.say('mimiron', '@hubot nlc data');
+		});
+	});
+
+	describe('user asks for training data for a specific classifier', function() {
+		it('should reply with slack attachment with current classifier data', function(done){
+			room.robot.on('ibmcloud.formatter', function(event) {
+				if (event.message){
+					expect(event.message).to.be.eql('NLC instance **cd02b5x110-nlc-0000** was trained with **2** classifications and **3** statements.');
+				}
+				if (event.attachments && event.attachments.length >= 1){
+					expect(event.attachments.length).to.eql(1);
+					expect(event.attachments[0].title).to.eql('Training Data for classifier ID cd02b5x110-nlc-0000');
+					expect(event.attachments[0].fields).to.have.length(2);
+					expect(event.attachments[0].fields[0].title).to.eql('classification');
+					expect(event.attachments[0].fields[0].value).to.eql('Sample text\nSample text 2\n');
+					done();
+				}
+			});
+			room.user.say('mimiron', '@hubot nlc data classification cd02b5x110-nlc-0000');
 		});
 	});
 

--- a/test/nlc.tests.js
+++ b/test/nlc.tests.js
@@ -336,6 +336,7 @@ describe('Test the NLC interaction', function(){
 					expect(event.message).to.contain(i18n.__('nlc.help.list'));
 					expect(event.message).to.contain(i18n.__('nlc.help.train'));
 					expect(event.message).to.contain(i18n.__('nlc.help.auto.approve'));
+					expect(event.message).to.contain(i18n.__('nlc.help.data'));
 					done();
 				}
 			});


### PR DESCRIPTION
Resolves #56 
- Adds the command `nlc data` that allows developers to see the data used to train the current NLC instance. 
- An optional parameter, `nlc data [className]` allows to filter the result statements to only those containing the given class name. 
